### PR TITLE
Improve/fix help for bc-import

### DIFF
--- a/BCManager/Config/Commands/en/Help/BCImport.txt
+++ b/BCManager/Config/Commands/en/Help/BCImport.txt
@@ -11,7 +11,7 @@
       Use bc-location (loc or pos also work) to display and store your current location
       Use bc-prefabs to get a list of prefabs in the Data/Prefabs folder
       /ne, /nw, /se, /sw - these options cause the prefab to spawn at the location in the direction indicated (instead of the center). If you face that direction it will appear in front of you
-      /cornernw, /cornernw, /cornerse, /cornersw - these options cause the prefab to spawn at the location from that corner (instead of the center)
+      /cornerne, /cornernw, /cornerse, /cornersw - these options cause the prefab to spawn at the location from that corner (instead of the center)
       /nooffset will cause the bottom layer of the prefab to spawn at y, without this option the -yoffset property is used to offset from the location given
       /air /noair /sleepers /nosleepers - will override the xml settings for the prefab when importing
       /noundo will skip the undo code and not make a backup of the area replaced by the import

--- a/BCManager/Config/Commands/en/Help/BCImport.txt
+++ b/BCManager/Config/Commands/en/Help/BCImport.txt
@@ -14,5 +14,9 @@
       /cornerne, /cornernw, /cornerse, /cornersw - these options cause the prefab to spawn at the location from that corner (instead of the center)
       /nooffset will cause the bottom layer of the prefab to spawn at y, without this option the -yoffset property is used to offset from the location given
       /air /noair - will override the xml settings for the prefab when importing
-      /editmode /sblock - will import sleeper blocks instead of spawning sleepers
+      /sblock - will import sleeper blocks instead of spawning sleepers
+      /tfill - will import terrain filler as terrain filler blocks instead of replacing them
+      /notrans - will import placerholder blocks as they are, instead of replacing them
+      /editmode - activates /sblock, /tfill and /notrans
+      /noreload /nr - Do not reload chunks for clients
       /noundo will skip the undo code and not make a backup of the area replaced by the import

--- a/BCManager/Config/Commands/en/Help/BCImport.txt
+++ b/BCManager/Config/Commands/en/Help/BCImport.txt
@@ -13,5 +13,6 @@
       /ne, /nw, /se, /sw - these options cause the prefab to spawn at the location in the direction indicated (instead of the center). If you face that direction it will appear in front of you
       /cornerne, /cornernw, /cornerse, /cornersw - these options cause the prefab to spawn at the location from that corner (instead of the center)
       /nooffset will cause the bottom layer of the prefab to spawn at y, without this option the -yoffset property is used to offset from the location given
-      /air /noair /sleepers /nosleepers - will override the xml settings for the prefab when importing
+      /air /noair - will override the xml settings for the prefab when importing
+      /editmode /sblock - will import sleeper blocks instead of spawning sleepers
       /noundo will skip the undo code and not make a backup of the area replaced by the import

--- a/BCManager/Config/Commands/en/Help/BCImport.txt
+++ b/BCManager/Config/Commands/en/Help/BCImport.txt
@@ -10,7 +10,7 @@
       Use bc-help to get a list of common /options
       Use bc-location (loc or pos also work) to display and store your current location
       Use bc-prefabs to get a list of prefabs in the Data/Prefabs folder
-      /nw, /nw, /se, /sw - these options cause the prefab to spawn at the location in the direction indicated (instead of the center). If you face that direction it will appear in front of you
+      /ne, /nw, /se, /sw - these options cause the prefab to spawn at the location in the direction indicated (instead of the center). If you face that direction it will appear in front of you
       /cornernw, /cornernw, /cornerse, /cornersw - these options cause the prefab to spawn at the location from that corner (instead of the center)
       /nooffset will cause the bottom layer of the prefab to spawn at y, without this option the -yoffset property is used to offset from the location given
       /air /noair /sleepers /nosleepers - will override the xml settings for the prefab when importing


### PR DESCRIPTION
Personally, I think all options should be moved into individual classes and the constants for them
referenced from that. Or, even better, have individual methods for every option. And, then, have
a code generation step in the build that creates the help files automatically from it.

Meanwhile, hth, hand.